### PR TITLE
Track ecommerce events with improved data

### DIFF
--- a/Faker/Request.php
+++ b/Faker/Request.php
@@ -807,8 +807,38 @@ class Request extends \Faker\Provider\Base
             'My Product',
             'Test Product',
             'Product Name',
-            'Awesome Product'
+            'Awesome Product',
+            'Helpful Product'
         ));
+    }
+
+    public function productSku()
+    {
+        return static::randomElement(array(
+            'SKU-1526',
+            'SKU-9526',
+            'SKU-1122',
+            'SKU-0111',
+            'SKU-1658',
+            'SKU-0122',
+            'SKU-9884',
+            'SKU-6585',
+            'SKU-5498',
+            'SKU-1238',
+        ));
+    }
+
+    public function categories($maximum = 1)
+    {
+        return static::randomElements(array(
+            'Music Category',
+            'Sale',
+            'Video Category',
+            'Second hand',
+            'Men only',
+            'Sports',
+            'Mobile stuff',
+        ), static::numberBetween(1, $maximum));
     }
 
     public function resolution()

--- a/Generator/VisitsFake.php
+++ b/Generator/VisitsFake.php
@@ -97,7 +97,7 @@ class VisitsFake extends Generator
                 $tracker->setUrl($site['main_url'] . $pageUrl);
 
                 if ($this->faker->boolean(10)) {
-                    $tracker->setEcommerceView($this->faker->numberBetween(1, 9999), $this->faker->productName, 'Music Category', $this->faker->randomNumber(2));
+                    $tracker->setEcommerceView($this->faker->productSku, $this->faker->productName, $this->faker->categories(5), $this->faker->randomNumber(2));
                 }
 
                 $tracker->doTrackPageView($this->faker->sentence());
@@ -150,7 +150,7 @@ class VisitsFake extends Generator
                 $price =  $this->faker->randomNumber(2);
                 $quantity = $this->faker->numberBetween(1,4);
 
-                $tracker->addEcommerceItem($sku = $this->faker->numberBetween(1, 9999), $this->faker->productName, 'Music Category', $price, $quantity);
+                $tracker->addEcommerceItem($this->faker->productSku, $this->faker->productName, $this->faker->categories(5), $price, $quantity);
 
                 if ($this->faker->boolean(50)) {
                     $tracker->doTrackEcommerceCartUpdate(50);


### PR DESCRIPTION
* Use a fixed set of possible SKUs (using a random number provides too many possible results for good reports)
* Send up to 5 random categories (instead of a fixed one)

refs https://github.com/matomo-org/matomo/pull/15999