### PR TITLE
Fix menu item definition

### DIFF
--- a/Menu.php
+++ b/Menu.php
@@ -15,11 +15,12 @@ class Menu extends \Piwik\Plugin\Menu
 {
     public function configureAdminMenu(MenuAdmin $menu)
     {
-        $menu->addDevelopmentItem(
-            'VisitorGenerator_VisitorGenerator',
-            array('module' => 'VisitorGenerator', 'action' => 'index'),
-            Piwik::hasUserSuperUserAccess(),
-            $order = 20
-        );
+        if (Piwik::hasUserSuperUserAccess()) {
+            $menu->addDevelopmentItem(
+                'VisitorGenerator_VisitorGenerator',
+                ['module' => 'VisitorGenerator', 'action' => 'index'],
+                $order = 20
+            );
+        }
     }
 }


### PR DESCRIPTION
Seem the menu item method definition has changed some when, but wasn't adjusted here.
Currently the VisitorGenerator menu item is shown to anyone, as the visibility parameter seems to have been removed and so no visibility check is performed.