### PR TITLE
Make plugin work with Matomo for WordPress

### DIFF
--- a/Generator.php
+++ b/Generator.php
@@ -9,6 +9,7 @@
 namespace Piwik\Plugins\VisitorGenerator;
 
 use Piwik\SettingsPiwik;
+use Piwik\SettingsServer;
 
 include_once __DIR__ . '/vendor/autoload.php';
 
@@ -25,6 +26,20 @@ class Generator
         $this->faker = \Faker\Factory::create('en_EN');
         $this->faker->addProvider(new Faker\Request($this->faker));
         $this->setMatomoUrl($matomoUrl);
+    }
+
+    protected function makeMatomoTracker($idSite)
+    {
+        if (SettingsServer::isMatomoForWordPress()) {
+            $trackerFile = plugin_dir_path( MATOMO_ANALYTICS_FILE ) . "tests/phpunit/framework/test-local-tracker.php";
+            if (file_exists($trackerFile)) {
+                include_once $trackerFile;
+                return new \MatomoLocalTracker($idSite, $this->getMatomoUrl());
+            } else {
+                throw new \Exception('The visitor generator in Matomo for WordPress works only when the plugin is installed from Git and is only intended for development.');
+            }
+        }
+        return new \MatomoTracker($idSite, $this->getMatomoUrl());
     }
 
     /**

--- a/Generator/VisitsFake.php
+++ b/Generator/VisitsFake.php
@@ -20,7 +20,7 @@ class VisitsFake extends Generator
     {
         $date = date("Y-m-d", $time);
 
-        $tracker = new \MatomoTracker(1, $this->getMatomoUrl());
+        $tracker = $this->makeMatomoTracker($idSite);
         $tracker->setDebugStringAppend('dp=1');
         $tracker->enableBulkTracking();
         $tokenAuth = Piwik::requestTemporarySystemAuthToken('VistorGenerator', 24);

--- a/Menu.php
+++ b/Menu.php
@@ -10,17 +10,26 @@ namespace Piwik\Plugins\VisitorGenerator;
 
 use Piwik\Menu\MenuAdmin;
 use Piwik\Piwik;
+use Piwik\SettingsServer;
 
 class Menu extends \Piwik\Plugin\Menu
 {
     public function configureAdminMenu(MenuAdmin $menu)
     {
         if (Piwik::hasUserSuperUserAccess()) {
-            $menu->addDevelopmentItem(
-                'VisitorGenerator_VisitorGenerator',
-                ['module' => 'VisitorGenerator', 'action' => 'index'],
-                $order = 20
-            );
+            if (SettingsServer::isMatomoForWordPress()) {
+                $menu->addSystemItem(
+                    'VisitorGenerator_VisitorGenerator',
+                    ['module' => 'VisitorGenerator', 'action' => 'index'],
+                    $order = 20
+                );
+            } else {
+                $menu->addDevelopmentItem(
+                    'VisitorGenerator_VisitorGenerator',
+                    ['module' => 'VisitorGenerator', 'action' => 'index'],
+                    $order = 20
+                );
+            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -46,14 +46,16 @@ VisitorGenerator makes a lot of requests to the Matomo tracking API to send the 
 
 ## Using it in Matomo for WordPress
 
-The developer menu item is not available in Matomo for WordPress. Visits have to be generated using the command line instead:
+It only works in Matomo for WordPress if the plugin is installed through git as it's only intended for development.
+
+In Matomo for WordPress you can find the UI in the Matomo Admin under "System".
+
+You can also use the command line to generate the data:
 
 ```
 cd wp-content/plugins/matomo/app
 ./console  visitorgenerator:generate-visits --idsite=1
 ```
-
-If you are getting an error about SSL errors then you can use the `--custom-matomo-url="..."` option to specify using HTTP. For example `--custom-matomo-url="http://my-domain/wp-content/plugins/matomo/app/"`.
 
 ### Legalnotice
 

--- a/templates/index.twig
+++ b/templates/index.twig
@@ -38,7 +38,6 @@
                  title="{{ 'VisitorGenerator_ChoiceYes'|translate|e('html_attr') }}">
             </div>
 
-            <input type="hidden" value="{{ token_auth }}" name="token_auth"/>
             <input type="hidden" value="{{ nonce }}" name="form_nonce"/>
 
             <p>


### PR DESCRIPTION
### Description:

Fix https://github.com/matomo-org/plugin-VisitorGenerator/issues/67

### Review

* [ ] Functional review done
* [ ] Potential edge cases thought about (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] Usability review done (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] Security review done [see checklist](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] Code review done
* [ ] Tests were added if useful/possible
* [ ] Reviewed for breaking changes
* [ ] Developer changelog updated if needed
* [ ] Documentation added if needed
* [ ] Existing documentation updated if needed
