### PR TITLE
Ensure console commands return integers

### DIFF
--- a/Commands/AnonymizeLog.php
+++ b/Commands/AnonymizeLog.php
@@ -59,6 +59,8 @@ This will anonymize the log file and place the log in the plugins/CustomVariable
 
         $target = $this->buildTargetFileName($plugin, $file);
         $this->saveFile($output, $target, $anonymized);
+
+        return 0;
     }
 
     private function getReplace(InputInterface $input)

--- a/Commands/GenerateAnnotation.php
+++ b/Commands/GenerateAnnotation.php
@@ -40,6 +40,8 @@ class GenerateAnnotation extends ConsoleCommand
         });
 
         $this->writeSuccessMessage($output, array('1 Annotation for today generated'));
+
+        return 0;
     }
 
 }

--- a/Commands/GenerateGoals.php
+++ b/Commands/GenerateGoals.php
@@ -42,6 +42,8 @@ class GenerateGoals extends ConsoleCommand
         $this->writeSuccessMessage($output, array(
             sprintf('idsite=%d, %d goals generated (idgoal from %d to %d)', $idSite, count($goalIds), reset($goalIds), end($goalIds))
         ));
+
+        return 0;
     }
 
 }

--- a/Commands/GenerateUsers.php
+++ b/Commands/GenerateUsers.php
@@ -35,6 +35,8 @@ class GenerateUsers extends ConsoleCommand
         });
 
         $this->writeSuccessMessage($output, array(count($userLogins) . ' Users generated'));
+
+        return 0;
     }
 
 }

--- a/Commands/GenerateVisits.php
+++ b/Commands/GenerateVisits.php
@@ -96,6 +96,8 @@ class GenerateVisits extends ConsoleCommand
             $nbActionsTotal . ' Visits generated',
             round($nbActionsTotal / $timer->getTime(), 0) . ' requests per second'
         ));
+
+        return 0;
     }
 
     private function getLimitFakeVisits(InputInterface $input)

--- a/Commands/GenerateWebsites.php
+++ b/Commands/GenerateWebsites.php
@@ -37,6 +37,8 @@ class GenerateWebsites extends ConsoleCommand
         $this->writeSuccessMessage($output, array(
             sprintf('%d Websites generated (idsite from %d to %d)', count($siteIds), reset($siteIds), end($siteIds))
         ));
+
+        return 0;
     }
 
 }

--- a/Commands/ShortenLog.php
+++ b/Commands/ShortenLog.php
@@ -67,6 +67,8 @@ Keeps 500 log lines per day as well as all lines containing the term "ec_id"
         }
 
         echo $shortened;
+
+        return 0;
     }
 
     private function containsTerm($line, $terms)


### PR DESCRIPTION
### Description:

Newer versions of symfony console will throw an error when a console command does not return an integer.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
