### PR TITLE
Fix: orderId=0 invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,3 +63,5 @@
   * Fixed deprecation warning from dependency
 - 5.1.2 - 2025-08-18
   * Started generating AI referrer URLs 
+- 5.1.3 - 2025-09-01
+  * Fix for generation of ecommerce order ID 0

--- a/Generator/VisitsFake.php
+++ b/Generator/VisitsFake.php
@@ -176,12 +176,17 @@ class VisitsFake extends Generator
                 if ($this->faker->boolean(50)) {
                     $tracker->doTrackEcommerceCartUpdate(50);
                 } else {
+                    $orderId = $this->faker->randomNumber(5);
+                    // randomNumber() can produce 0, which is an invalid order number.
+                    if (0 === $orderId) {
+                        $orderId = 1;
+                    }
                     $subtotal = $price * $quantity;
                     $tax = $subtotal * 0.19;
                     $shipping = $subtotal * 0.05;
                     $discount = $subtotal * 0.10;
                     $grandTotal = $subtotal + $shipping + $tax - $discount;
-                    $tracker->doTrackEcommerceOrder($this->faker->randomNumber(5), $grandTotal, $subtotal, $tax, $shipping, $discount);
+                    $tracker->doTrackEcommerceOrder($orderId, $grandTotal, $subtotal, $tax, $shipping, $discount);
                 }
             }
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "VisitorGenerator",
-    "version": "5.1.2",
+    "version": "5.1.3",
     "description": "Developer tool that lets you generate fake visits. Useful if you are working with plugins or themes or if you use the Matomo API.",
     "keywords": ["development", "tools"],
     "license": "GPL v3+",


### PR DESCRIPTION
## Description

Occasionally, an orderId of 0 was generated, which is invalid.

<img width="1866" height="780" alt="image" src="https://github.com/user-attachments/assets/23ee3308-91f1-4f07-8d96-46bcb7a29e11" />


## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✖] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?