### PR TITLE
Replace Piwik with Matomo in request URL, #PG-4689

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,5 @@
   * Started generating AI referrer URLs 
 - 5.1.3 - 2025-09-01
   * Fix for generation of ecommerce order ID 0
+- 5.1.4 - 2025-10-27
+  * Replace Piwik with Matomo in request URL

--- a/Generator/VisitsFromLogs.php
+++ b/Generator/VisitsFromLogs.php
@@ -87,6 +87,9 @@ class VisitsFromLogs extends Generator
 
     protected function manipulateRequestUrl($time, $idSite, $url, $date, $ip, $prefix)
     {
+        $url = str_replace(['piwik', 'Piwik'], ['matomo', 'Matomo'], $url);
+        // replace anything else that is not from above list
+        $url = str_ireplace('piwik', 'matomo', $url);
         $start = strpos($url, 'matomo.php?') + strlen('matomo.php?');
         $url   = substr($url, $start);
         $ip    = strlen($ip) < 9 ? "13.5.111.3" : $ip;

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "VisitorGenerator",
-    "version": "5.1.3",
+    "version": "5.1.4",
     "description": "Developer tool that lets you generate fake visits. Useful if you are working with plugins or themes or if you use the Matomo API.",
     "keywords": ["development", "tools"],
     "license": "GPL v3+",


### PR DESCRIPTION
## Description
Replace Piwik with Matomo in request URL, #PG-4689.

In `demo.matomo.cloud` there are events being reported as `GetPiwik` and this is not good for Sales, so they want to update the references to Matomo from Piwik

## Issue No
#PG-4689

## Steps to Replicate the Issue



## Checklist
- [✔] Tested locally or on demo2/demo3?
- [✖] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✔] Version bumped?