### PR TITLE
Add optional word prefix to order ID since they don't have to be just numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,3 +68,5 @@
 - 5.1.4 - 2025-11-10
   * Randomly mark visits as NovaAct agent also
   * Added new command to send fake AI Bot Requests
+- 5.1.5 - 2025-11-24
+  * Generate string order IDs occasionally

--- a/Generator/VisitsFake.php
+++ b/Generator/VisitsFake.php
@@ -186,11 +186,11 @@ class VisitsFake extends Generator
                 if ($this->faker->boolean(50)) {
                     $tracker->doTrackEcommerceCartUpdate(50);
                 } else {
-                    $orderId = $this->faker->randomNumber(5);
-                    // randomNumber() can produce 0, which is an invalid order number.
-                    if (0 === $orderId) {
-                        $orderId = 1;
-                    }
+                    do {
+                        $randomNumber = (string) $this->faker->randomNumber(5);
+                        $orderId = $this->faker->boolean(50) ? ($this->faker->word() . '-' . $randomNumber) : $randomNumber;
+                    } while ('0' === $orderId);
+
                     $subtotal = $price * $quantity;
                     $tax = $subtotal * 0.19;
                     $shipping = $subtotal * 0.05;

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "VisitorGenerator",
-    "version": "5.1.4",
+    "version": "5.1.5",
     "description": "Developer tool that lets you generate fake visits. Useful if you are working with plugins or themes or if you use the Matomo API.",
     "keywords": ["development", "tools"],
     "license": "GPL v3+",


### PR DESCRIPTION
## Description

Better reflecting real-word order IDs that don't have to be just numeric.

Note: not sure when the next release date is planned for, anyone can change it whatever it needs to be. Thanks!

## Issue No
Related to testing for DEV-19682.

## Checklist
- [✔] Tested locally
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?