### PR TITLE
De-assign user id with null instead of false (type-safe tracker)

### DIFF
--- a/Generator/VisitsFake.php
+++ b/Generator/VisitsFake.php
@@ -77,7 +77,7 @@ class VisitsFake extends Generator
                 if ($this->faker->boolean(50)) {
                     $tracker->setUserId($this->faker->firstName);
                 } else {
-                    $tracker->setUserId(false);
+                    $tracker->setUserId(null);
                 }
             }
 


### PR DESCRIPTION
The modernized, type-safe `MatomoTracker` types `setUserId()` as `?string`; passing `false` coerces to `''` and is rejected. Use `null` to de-assign a user id.

Part of Matomo 6 preparation (core moves matomo-php-tracker to the type-safe branch / future v4).

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules