### PR TITLE
Allow manually dispatching the PHPCS workflow [ignore_release]

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -2,10 +2,6 @@ name: PHPCS check
 
 on:
   pull_request:
-  push:
-    branches:
-      - 5.x-dev
-      - 6.x-dev
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,6 +1,12 @@
 name: PHPCS check
 
-on: pull_request
+on:
+  pull_request:
+  push:
+    branches:
+      - 5.x-dev
+      - 6.x-dev
+  workflow_dispatch:
 
 permissions:
   actions: read


### PR DESCRIPTION
## Description
The PHPCS badge for this plugin (shown on the plugins build dashboard) has displayed "failing" since December 2025 even though PHPCS passes on all recent pull requests. The badge shows the latest workflow run whose head branch matches the default branch, and that run is a failed December 2025 run from a fork PR whose branch was named `5.x-dev`. Because the workflow only triggers on `pull_request`, no future run can replace that badge state on its own.

This adds a `workflow_dispatch` trigger so the workflow can be run manually; a single dispatch on `5.x-dev` after merging refreshes the badge. PHPCS otherwise stays PR-only, since it is already enforced on every PR before merge. CI-only change with no runtime effect.

## Issue No
NA

## Steps to Replicate the Issue
1. Open the plugins build dashboard and look at the VisitorGenerator PHPCS badge.
2. Expected: the badge reflects the current state of the code on 5.x-dev.
3. Actual: the badge shows a failing December 2025 run and can never update, as the workflow only runs on pull requests.

## Checklist
- [NA] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [✖] Version bumped?
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
- [NA] Documentation updated?

